### PR TITLE
[DO NOT MERGE][EXPERIMENT] Experiment with buffer/typedarrays

### DIFF
--- a/.github/workflows/installation-and-benchmark.yml
+++ b/.github/workflows/installation-and-benchmark.yml
@@ -1,9 +1,6 @@
 name: Installation and Benchmarks
 
 on:
-  pull_request:
-    branches:
-      - main
 #  push:
 #    branches:
 #      - main

--- a/.github/workflows/installation-and-benchmark.yml
+++ b/.github/workflows/installation-and-benchmark.yml
@@ -1,6 +1,9 @@
 name: Installation and Benchmarks
 
 on:
+  pull_request:
+    branches:
+      - main
 #  push:
 #    branches:
 #      - main

--- a/__test__/index.spec.mjs
+++ b/__test__/index.spec.mjs
@@ -1,6 +1,6 @@
 import test from "ava";
 
-import { sha256, sha512, sha512Buf } from "../lib/index.mjs";
+import { sha256, sha256Buf, sha512, sha512Buf } from "../lib/index.mjs";
 
 test("sha256 from native", (t) => {
   t.is(
@@ -21,5 +21,12 @@ test("sha512Buf from native", (t) => {
   t.is(
     sha512Buf(Buffer.from("Hello world!")),
     "f6cde2a0f819314cdde55fc227d8d7dae3d28cc556222a0a8ad66d91ccad4aad6094f517a2182360c9aacf6a3dc323162cb6fd8cdffedb0fe038f55e85ffb5b6",
+  );
+});
+
+test("sha256Buf from native", (t) => {
+  t.is(
+    sha256Buf(Buffer.from("Hello world!")),
+    "c0535e4be2b79ffd93291305436bf889314e4a3faec05ecffcbb7df31ad9e51a",
   );
 });

--- a/__test__/index.spec.mjs
+++ b/__test__/index.spec.mjs
@@ -1,6 +1,6 @@
 import test from "ava";
 
-import { sha256, sha512 } from "../lib/index.mjs";
+import { sha256, sha512, sha512Buf } from "../lib/index.mjs";
 
 test("sha256 from native", (t) => {
   t.is(
@@ -12,6 +12,14 @@ test("sha256 from native", (t) => {
 test("sha512 from native", (t) => {
   t.is(
     sha512("Hello world!"),
+    "f6cde2a0f819314cdde55fc227d8d7dae3d28cc556222a0a8ad66d91ccad4aad6094f517a2182360c9aacf6a3dc323162cb6fd8cdffedb0fe038f55e85ffb5b6",
+  );
+});
+
+// TODO: REMOVE
+test("sha512Buf from native", (t) => {
+  t.is(
+    sha512Buf(Buffer.from("Hello world!")),
     "f6cde2a0f819314cdde55fc227d8d7dae3d28cc556222a0a8ad66d91ccad4aad6094f517a2182360c9aacf6a3dc323162cb6fd8cdffedb0fe038f55e85ffb5b6",
   );
 });

--- a/benchmark/benchmark.mjs
+++ b/benchmark/benchmark.mjs
@@ -1,6 +1,6 @@
 import Benchmark from "benchmark";
 import crypto from "node:crypto";
-import { sha256 } from "../lib/index.mjs";
+import { sha256, sha256Buf } from "../lib/index.mjs";
 
 const hashJs = (val) => crypto.createHash("sha256").update(val).digest("hex");
 
@@ -19,17 +19,28 @@ const measure = async (size) => {
         i = (i + 1) % N;
         sha256(values[i]);
       })
+      .add("rust (buffer)", () => {
+        i = (i + 1) % N;
+        sha256Buf(Buffer.from(values[i]));
+      })
       .add("js", () => {
         i = (i + 1) % N;
         hashJs(values[i]);
       })
 
       .on("complete", function () {
-        const fastest = this.filter("fastest")[0];
-        const slowest = this.filter("slowest")[0];
+        const _results = this.filter("successful");
+        const results = [_results[0], _results[1], _results[2]].sort(
+          (a, b) => a.stats.mean - b.stats.mean,
+        );
 
-        const jsResult = fastest.name === "js" ? fastest : slowest;
-        const rustResult = fastest.name === "rust" ? fastest : slowest;
+        const jsResult = results.find((r) => r.name === "js");
+        const rustResult = results.find((r) => r.name === "rust");
+        const rustBufferResult = results.find(
+          (r) => r.name === "rust (buffer)",
+        );
+        const fastest = results[0],
+          slowest = results[2];
 
         resolve([
           Benchmark.formatNumber(size),
@@ -37,9 +48,11 @@ const measure = async (size) => {
             " ops/sec",
           Benchmark.formatNumber(Math.round(1 / rustResult.stats.mean)) +
             " ops/sec",
-          `**${fastest === rustResult ? "🦀 Rust" : "🟢 JS"}** (${(
+          Benchmark.formatNumber(Math.round(1 / rustBufferResult.stats.mean)) +
+            " ops/sec",
+          `**${fastest.name}** (${(
             slowest.stats.mean / fastest.stats.mean
-          ).toFixed(3)}x as fast)`,
+          ).toFixed(3)}x as fast as ${slowest.name})`,
         ]);
       })
       .run({ async: true });
@@ -48,11 +61,18 @@ const measure = async (size) => {
 
 const main = async () => {
   const sizes = [10, 100, 500, 1000, 10000];
+  // const sizes = [10];
   const results = await Promise.all(sizes.map(measure));
 
   const table = [
-    ["Input Length", "Node.js Impl", "Rust/NAPI Impl", "Fastest"],
-    ["---", "---", "---", "---"],
+    [
+      "Input Length",
+      "Node.js Impl",
+      "Rust/NAPI Impl",
+      "Rust with Buffer",
+      "Fastest",
+    ],
+    ["---", "---", "---", "---", "---"],
     ...results,
   ]
     .map((row) => row.join(" | "))

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -4,5 +4,6 @@ const require = createRequire(import.meta.url);
 const lib = require("./node-fast-sha.node")
 
 
-export const sha256 = lib.sha256
-export const sha512 = lib.sha512
+export const sha256 = lib.sha256;
+export const sha512 = lib.sha512;
+export const sha512Buf = lib.sha512Buf; // TODO REMOVE

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -1,9 +1,9 @@
 import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 
-const lib = require("./node-fast-sha.node")
-
+const lib = require("./node-fast-sha.node");
 
 export const sha256 = lib.sha256;
 export const sha512 = lib.sha512;
 export const sha512Buf = lib.sha512Buf; // TODO REMOVE
+export const sha256Buf = lib.sha256Buf; // TODO REMOVE

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![deny(clippy::all)]
+use std::borrow::Cow;
+use napi::bindgen_prelude::Buffer;
 use sha2::{Digest, Sha256, Sha512};
 
 #[macro_use]
@@ -8,6 +10,17 @@ extern crate napi_derive;
 pub fn sha512(input: String) -> String {
   let mut hasher = Sha512::new();
   hasher.update(input);
+  let result = hasher.finalize();
+  format!("{:x}", result)
+}
+
+// TODO: REMOVE
+#[napi]
+pub fn sha512_buf(buf: Buffer) -> String {
+  let mut hasher = Sha512::new();
+  let input: Cow<'_, str> = String::from_utf8_lossy(&buf);
+
+  hasher.update(input.into_owned());
   let result = hasher.finalize();
   format!("{:x}", result)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,3 +32,14 @@ pub fn sha256(input: String) -> String {
   let result = hasher.finalize();
   format!("{:x}", result)
 }
+
+// TODO: REMOVE
+#[napi]
+pub fn sha256_buf(buf: Buffer) -> String {
+  let mut hasher = Sha256::new();
+  let input: Cow<'_, str> = String::from_utf8_lossy(&buf);
+
+  hasher.update(input.into_owned());
+  let result = hasher.finalize();
+  format!("{:x}", result)
+}


### PR DESCRIPTION
Thinking about the serialization cost of large string _inputs_, I found https://napi.rs/docs/concepts/typed-arraywhich notes that:

> `TypedArray` describes an array-like view of an underlying binary data buffer. Using `TypedArray` allows you to share data between Node.js and Rust without copy or move data underlying.

So, I did a quick and dirty implementation to switch a string arg with a Buffer. Some notes:
* No idea if I actually did this right and haven't verified that the `Buffer` arg is actually passed by reference
* Both JS and Rust sides take a hit of converting to and from a buffer. Not sure if those in runtime conversions are more expensive than the serialization cost of sending a string copy via arguments.
* The conversion to string on the Rust side is almost assuredly incorrect for all charsets and things outside of convenient ASCII
* I didn't do anything with the return value because return string is fixed length and presumably low overhead.

Anyhoo, take a look if interesting. No worries if not. Close it down and delete whenever.